### PR TITLE
Set fixed height for header

### DIFF
--- a/dist/scss/abstracts/_variables.scss
+++ b/dist/scss/abstracts/_variables.scss
@@ -1,0 +1,1 @@
+$header-navigation-height: 81.7px !default; 

--- a/dist/scss/pages/components/Header.scss
+++ b/dist/scss/pages/components/Header.scss
@@ -1,4 +1,9 @@
 .ordino-header-navigation {
   background: #006192;
   padding: 0.5rem;
+  
+  // set fixed height to the header to avoid flickering when switching tabs
+  @media (min-width: 992px) { // burger menu appears
+    height: $header-navigation-height;
+  }
 }

--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,0 +1,1 @@
+$header-navigation-height: 81.7px !default; 

--- a/src/scss/pages/components/Header.scss
+++ b/src/scss/pages/components/Header.scss
@@ -1,4 +1,9 @@
 .ordino-header-navigation {
   background: #006192;
   padding: 0.5rem;
+  
+  // set fixed height to the header to avoid flickering when switching tabs
+  @media (min-width: 992px) { // burger menu appears
+    height: $header-navigation-height;
+  }
 }


### PR DESCRIPTION

Added a fixed height to avoid flickering when switching tabs. 
Note: Only applies when the `screen > 992 px`.  When `screen < 992 px` the header tabs collapse and the height is variable and depends on the tabs 